### PR TITLE
Separate logger and add completion event

### DIFF
--- a/cmd/record/record.go
+++ b/cmd/record/record.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/compspec/compat-lib/pkg/fs"
+	"github.com/compspec/compat-lib/pkg/logger"
 )
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 
 	// We require a recording file for the recorder
 	if *outfile == "" {
-		*outfile = fs.GetEventFile(*outdir)
+		*outfile = logger.GetEventFile(*outdir)
 	}
 	// Generate the fusefs server
 	compatFS, err := fs.NewCompatFS(mountPath, *outfile)
@@ -64,6 +65,9 @@ func main() {
 	call := strings.Join(args, " ")
 	fmt.Println(call)
 	err = compatFS.RunCommand(call)
+
+	// Record the end of command event.
+	logger.LogEvent("Complete", logger.Outfile)
 	if err != nil {
 		log.Panicf("Error running command: %s", err)
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/compspec/compat-lib/pkg/logger"
 	"github.com/google/shlex"
 	"github.com/hanwen/go-fuse/v2/fuse"
 )
@@ -45,9 +46,9 @@ func (c *CompatFS) Cleanup() {
 	// Clean up mount point directory
 	fmt.Printf("Cleaning up %s...\n", c.MountPoint)
 	os.RemoveAll(c.MountPoint)
-	if outfile != "" {
-		fmt.Printf("Output file written to %s\n", outfile)
-		os.Chmod(outfile, 0644)
+	if logger.Outfile != "" {
+		fmt.Printf("Output file written to %s\n", logger.Outfile)
+		os.Chmod(logger.Outfile, 0644)
 	}
 }
 
@@ -62,10 +63,10 @@ func NewCompatFS(
 ) (*CompatFS, error) {
 
 	// Create a Compat Filesystem with defaults
-	compat := CompatFS{Outfile: outfile}
+	compat := CompatFS{Outfile: logger.Outfile}
 
 	// Set the global log file in case we are recording events
-	outfile = recordFile
+	logger.SetOutfile(recordFile)
 
 	// TODO keep track of cpu and memory profiles
 	if mountPath == "" {

--- a/pkg/fs/loopback.go
+++ b/pkg/fs/loopback.go
@@ -2,13 +2,13 @@ package fs
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"syscall"
 	"time"
 
+	"github.com/compspec/compat-lib/pkg/logger"
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 )
@@ -33,7 +33,7 @@ func (n *CompatLoopbackNode) Lookup(ctx context.Context, name string, out *fuse.
 	if err != nil {
 		return nil, fs.ToErrno(err)
 	}
-	logEvent("Lookup", p)
+	logger.LogEvent("Lookup", p)
 	out.Attr.FromStat(&st)
 	node := newNode(n.RootData, n.EmbeddedInode(), name, &st)
 	ch := n.NewInode(ctx, node, idFromStat(n.RootData, &st))
@@ -68,15 +68,13 @@ func (n *CompatLoopbackNode) root() *fs.Inode {
 func (n *CompatLoopbackNode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	flags = flags &^ syscall.O_APPEND
 	p := n.path()
-	logEvent("Open", p)
-	fmt.Printf("CUSTOM OPEN FOR %s with flags %d\n", p, flags)
+	logger.LogEvent("Open", p)
 	fh, flags, errno := n.LoopbackNode.Open(ctx, flags)
 	return fh, flags, errno
 }
 
 func (n *CompatLoopbackNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
-	logEvent("Create", name)
-	//	fmt.Printf("CUSTOM CREATE FOR %s with flags %d\n", name, flags)
+	logger.LogEvent("Create", name)
 	inode, fh, flags, errno := n.LoopbackNode.Create(ctx, name, flags, mode, out)
 	return inode, fh, flags, errno
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-package fs
+package logger
 
 import (
 	"log"
@@ -9,10 +9,18 @@ import (
 
 // logger will record events for the recorder to file
 var (
-	logger  *log.Logger
-	once    sync.Once
-	outfile string
+	logger *log.Logger
+	once   sync.Once
+
+	// Default output file available for setting externally
+	Outfile string
 )
+
+// SetOutfile can be called from an external class to set
+// the global variable.
+func SetOutfile(outfile string) {
+	Outfile = outfile
+}
 
 // GetEventFile gets an event file
 func GetEventFile(outdir string) string {
@@ -38,9 +46,9 @@ func GetEventFile(outdir string) string {
 }
 
 // logEvent logs the event to file with a unix nano timeseconds
-func logEvent(event, path string) {
+func LogEvent(event, path string) {
 	// Cut out early if we didn't define a log file
-	if outfile == "" {
+	if Outfile == "" {
 		return
 	}
 	logger := getLogger()
@@ -49,7 +57,7 @@ func logEvent(event, path string) {
 
 func getLogger() *log.Logger {
 	once.Do(func() {
-		file, err := os.OpenFile(outfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		file, err := os.OpenFile(Outfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This changeset adds moving the logger to a separate module, and also adding logging of a completion event, which is important to be able to derive the timestamp for the last state to endure. For the "path" I added the output file, so it's represented somewhere in the data.